### PR TITLE
在README.md中添加兼容性说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,16 @@ allprojects {
     implementation 'androidx.appcompat:appcompat:1.0.0'
     
     /*添加依赖*/
-    implementation 'com.github.yuzhiqiang1993:zxing:2.2.5'
+    implementation 'com.github.yuzhiqiang1993:zxing:2.2.9'
 }
 
  
+ ```
+
+ **注意**：本项目2.2.9版本引用了Zxing3.4.1，不兼容Android7.0以下、API level 24 以下的版本。若需兼容旧版本的安卓系统，请使用本项目2.2.8或更早的版本。
+ 
+ ```
+ implementation 'com.github.yuzhiqiang1993:zxing:2.2.8'
  ```
  
  2.权限


### PR DESCRIPTION
本项目2.2.9中引用了Zxing3.4.1，不再支持Android 7.0以下的手机。

> Note that release 3.4.0 and later requires Java 8, which requires targeting API level 24 or later. For a possible way to use it with earlier API levels, see
https://github.com/zxing/zxing/wiki/Frequently-Asked-Questions#it-doesnt-work-with-java-7--no-interface-method-sortljavautilcomparator
or simply use an earlier release.

为避免以后使用时遇到同样的兼容性问题，在README.md中添加兼容性说明。

#202 